### PR TITLE
HDF5: disable building test executables and running tests

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -73,7 +73,8 @@ if [[ -n ${FC} ]]; then
 else
     HDF5_ENABLE_FORTRAN=no
 fi
-./configure --prefix=${HDF5_DIR} --with-zlib=${ZLIB_DIR} --enable-cxx=${HDF5_ENABLE_CXX} --enable-fortran=${HDF5_ENABLE_FORTRAN} --enable-fortran2003=${HDF5_ENABLE_FORTRAN} --disable-shared --enable-static-exec
+# disable HDF5 tests since they create ~2GB of test files
+./configure --prefix=${HDF5_DIR} --with-zlib=${ZLIB_DIR} --enable-cxx=${HDF5_ENABLE_CXX} --enable-fortran=${HDF5_ENABLE_FORTRAN} --enable-fortran2003=${HDF5_ENABLE_FORTRAN} --enable-tests=no --disable-shared --enable-static-exec
 
 echo "HDF5: Building..."
 ${MAKE}


### PR DESCRIPTION
we never run the tests (they fail or take too long or create files too big) but still build them which also uses ~2GB of disk space and can lead to build failures when disk quota is tight.